### PR TITLE
Install webpack modules

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,5 @@
+{
+    "preset": "google",
+    "validateIndentation": 4,
+    "disallowTrailingWhitespace": true
+}

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ INTERMEDIATE_STEPS ?= echo nothing
 
 JS_FILES=static/js/src
 
-all: jshint jscs install-modules
+all: jshint jscs webpack
 
 include *.mk
 
@@ -17,7 +17,3 @@ $(PUBLIC)/js/all.json: $(PUBLIC)/json/all/index.html
 runserver-zarina:
 	hugo --buildDrafts --verboseLog=true -v
 	hugo server --baseUrl=http://kodos.ccnmtl.columbia.edu/ --bind=0.0.0.0 --port=13093 --watch --buildDrafts --verboseLog=true -v
-
-install-modules:
-	ln -sf ../../node_modules/supportservices-pack static/lib/supportservices-pack
-	ln -sf ../../node_modules/specialneedsvisit-pack static/lib/specialneedsvisit-pack

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ INTERMEDIATE_STEPS ?= echo nothing
 
 JS_FILES=static/js/src
 
-all: jshint jscs
+all: jshint jscs install-modules
 
 include *.mk
 
@@ -17,3 +17,7 @@ $(PUBLIC)/js/all.json: $(PUBLIC)/json/all/index.html
 runserver-zarina:
 	hugo --buildDrafts --verboseLog=true -v
 	hugo server --baseUrl=http://kodos.ccnmtl.columbia.edu/ --bind=0.0.0.0 --port=13093 --watch --buildDrafts --verboseLog=true -v
+
+install-modules:
+	ln -sf ../../node_modules/supportservices-pack static/lib/supportservices-pack
+	ln -sf ../../node_modules/specialneedsvisit-pack static/lib/specialneedsvisit-pack

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "url": "https://github.com/ccnmtl/passhugo/issues"
   },
   "dependencies": {
-    "specialneedsvisit-pack": "^0.1.1",
-    "supportservices-pack": "^0.1.1"
+    "specialneedsvisit-pack": "^0.1.3",
+    "supportservices-pack": "^0.1.2",
+    "webpack": "^1.13.1"
   },
   "devDependencies": {
     "jshint": "~2.9.1-rc1",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "passhugo",
+  "version": "0.1.0",
+  "description": "",
+  "main": "",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/ccnmtl/passhugo.git"
+  },
+  "author": "",
+  "license": "BSD-2-Clause",
+  "bugs": {
+    "url": "https://github.com/ccnmtl/passhugo/issues"
+  },
+  "dependencies": {
+    "specialneedsvisit-pack": "^0.1.1",
+    "supportservices-pack": "^0.1.1"
+  },
+  "devDependencies": {
+    "jshint": "~2.9.1-rc1",
+    "jscs": "~2.7.0"
+  }
+}

--- a/static/js/src/quiz.js
+++ b/static/js/src/quiz.js
@@ -1,0 +1,1 @@
+/* Rhetorical Quiz Code */

--- a/static/lib/.gitignore
+++ b/static/lib/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/webpack.mk
+++ b/webpack.mk
@@ -1,0 +1,7 @@
+WEBPACK_UTIL=./node_modules/webpack/bin/webpack.js
+OUTPUT_PATH=static/lib/
+
+webpack:
+	rm -rf static/lib/*
+	$(WEBPACK_UTIL) --output-path $(OUTPUT_PATH)supportservices/ --config ./node_modules/supportservices-pack/webpack.config.js
+	$(WEBPACK_UTIL) --output-path $(OUTPUT_PATH)specialneedsvisit/ --config ./node_modules/specialneedsvisit-pack/webpack.config.js


### PR DESCRIPTION
Opinions welcome on this approach. The webpack modules need to get into hugo's static directory to be served. Once the modules are installed via npm, the Makefile symlinks into the static directory. This works, but symlinks are obviously not completely ideal.

* adding package.json to project
* installing associated modules via npm
* symlink'ing the modules into the static directory
* adding a quiz.js stub in prep for rhetorical quiz logic